### PR TITLE
Fix weekly adv stats

### DIFF
--- a/.github/workflows/update_advanced_stats.yaml
+++ b/.github/workflows/update_advanced_stats.yaml
@@ -20,6 +20,7 @@ jobs:
 
     env:
       GITHUB_PAT: ${{ secrets.NFLVERSE_GH_TOKEN }}
+      SCRAPEOPS_API_KEY: ${{ secrets.NFLVERSE_SCRAPEOPS_API_KEY }}
       R_KEEP_PKG_SOURCE: yes
 
     steps:
@@ -32,8 +33,10 @@ jobs:
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
-        with: 
-          extra-packages:  nflverse/nflverse-data
+        with:
+          extra-packages:  |
+            nflverse/nflverse-data
+            nflverse/undercover
 
       - name: Run update script
         run: Rscript -e 'source("auto/update_adv_stats.R")'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Imports:
     tidyr (>= 1.1.3)
 Remotes:
     nflverse/nflreadr
+    nflverse/undercover
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)

--- a/R/game_advstats.R
+++ b/R/game_advstats.R
@@ -7,9 +7,13 @@
 #' @export
 pfr_game_adv_stats <- function(game_id){
 
-  raw_boxscores <- glue::glue("https://www.pro-football-reference.com/boxscores/{game_id}.htm") |>
-    polite::bow() |>
-    polite::scrape()
+  # For testing
+  # game_id <- "202302120phi"
+
+  undercover_response <- glue::glue("https://www.pro-football-reference.com/boxscores/{game_id}.htm") |>
+    undercover::scrapeops_request()
+
+  raw_boxscores <- attr(undercover_response, "response") |> httr::content()
 
   raw_def <- .pfr_read_advanced("defense", raw_boxscores)
 

--- a/auto/update_adv_stats.R
+++ b/auto/update_adv_stats.R
@@ -62,7 +62,7 @@ scrape_advstats <- function(){
     repo = "nflverse/nflverse-pfr",
     tag = "advstats_raw") |>
     nflreadr::rds_from_url() |>
-    dplyr::filter(!pfr_game_id %in% completed_games$pfr_game_id)
+    dplyr::filter(!pfr_game_id %in% scrape_games$pfr_game_id)
 
   all_games <- dplyr::bind_rows(archived_games,scrape_games) |>
     dplyr::distinct()

--- a/auto/update_adv_stats.R
+++ b/auto/update_adv_stats.R
@@ -13,7 +13,8 @@ scrape_advstats <- function(){
   completed_games <- piggyback::pb_download_url(
     file = "scraped_games.csv",
     repo = "nflverse/nflverse-pfr",
-    tag = "advstats_raw") |>
+    tag = "advstats_raw"
+  ) |>
     data.table::fread()
 
   game_ids <- nflreadr::load_schedules() %>%
@@ -22,7 +23,8 @@ scrape_advstats <- function(){
       !is.na(result),
       season >= 2018
     ) %>%
-    dplyr::select(pfr_game_id = pfr)
+    dplyr::select(pfr_game_id = pfr) |>
+    dplyr::slice_sample(n = 100)
 
   if(nrow(game_ids)==0) {
     cli::cli_alert_danger("No new games to scrape!")

--- a/auto/update_adv_stats.R
+++ b/auto/update_adv_stats.R
@@ -76,7 +76,6 @@ scrape_advstats <- function(){
 
   all_games |>
     dplyr::distinct(pfr_game_id, stat_type) |>
-    dplyr::bind_rows(completed_games) |>
     dplyr::arrange(pfr_game_id, stat_type) |>
     write.csv(here::here("build/scraped_games.csv"), quote = TRUE, row.names = FALSE)
 


### PR DESCRIPTION
closes #30 

This PR 

- fixes the underlying issue of #30 - an incorrect filter, 
- updates the scraper to use the nflverse internal package undercover
- limits the scraper to srape 100 games in one run

The 100 game limit is intended to reduce possible problems with the rebuild of the archived games file which has been killed by the incorrect filter.

As soon as this PR is merged, we have to release a new version of `scraped_games.csv` to trigger the scraper